### PR TITLE
デッキ編集画面UIの変更

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,3 +14,4 @@ RUN apt update \
     && rustup component add rust-src --toolchain 1.47.0-x86_64-unknown-linux-gnu \
     && rustup component add rls --toolchain 1.47.0-x86_64-unknown-linux-gnu \
     && cargo install diesel_cli --no-default-features --features postgres \
+    &% cargo install cargo-watch

--- a/templates/base.html
+++ b/templates/base.html
@@ -71,6 +71,9 @@
         integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
         crossorigin="anonymous"></script>
 
+    <!-- lazyload for images -->
+    <script src="https://cdn.jsdelivr.net/npm/lazyload@2.0.0-rc.2/lazyload.min.js"></script>
+
     <script>
         $("[data-toggle=popover]").popover({
             html: true,

--- a/templates/card.html
+++ b/templates/card.html
@@ -11,35 +11,48 @@
     </p>
     <form class="form-horizontal" method="POST" action="/card/delete" enctype="multipart/form-data">
         <button type="submit" id="deleteCardsButton" class="btn btn-danger">削除</button>
-        <table class="table">
-            <thead>
-                <tr>
-                    <th scope="col">チェック</th>
-                    <th scope="col">ID</th>
-                    <th scope="col">表画像</th>
-                    <th scope="col">裏画像</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for card in cards %}
-                <tr>
-                    <th>
-                        <div class="form-check">
-                            <input name="card_id[]" value="{{ card.id }}" class="form-check-input position-static"
-                                type="checkbox">
-                        </div>
-                    </th>
-                    <th>{{ card.id }}</th>
-                    <td><a href="{{ card.face }}">{{ card.face }}</td>
-                    <td><a href="{{ card.back }}">{{ card.back }}</td>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+        <div style="height:700px; overflow-y:scroll;">
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th scope="col">チェック</th>
+                        <th scope="col">ID</th>
+                        <th scope="col">表画像</th>
+                        <th scope="col">裏画像</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for card in cards %}
+                    <tr>
+                        <th>
+                            <div class="form-check">
+                                <input name="card_id[]" value="{{ card.id }}" class="form-check-input position-static"
+                                    type="checkbox">
+                            </div>
+                        </th>
+                        <th>{{ card.id }}</th>
+                        <td><img class="lazyload" data-src="{{ card.face }}" width="40" height="60"
+                                onmouseover="this.width=320; this.height=480"
+                                onmouseout="this.width=40; this.height=60" /><a href="{{ card.face }}">{{ card.face |
+                                split(pat="/") | last | split(pat=".") | first |
+                                truncate(length=20) }}</td>
+                        <td><img class="lazyload" data-src="{{ card.back }}" width="40" height="60"
+                                onmouseover="this.width=320; this.height=480"
+                                onmouseout="this.width=40; this.height=60" /><a href="{{ card.back }}">{{ card.back |
+                                split(pat="/") | last | split(pat=".") | first |
+                                truncate(length=20) }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
     </form>
 </div>
 <script>
     window.onload = function () {
+        // 画像の遅延読み込み
+        lazyload();
+
         const deleteButton = document.getElementById("deleteCardsButton");
         deleteButton.addEventListener("click", function (event) {
             const isConfirmed = confirm("本当に削除しますか？");

--- a/templates/deck.html
+++ b/templates/deck.html
@@ -30,7 +30,7 @@
                     {% endfor %}
                 </select>
             </div>
-            <button type="submit" id="deleteDeckButton" class="btn btn-primary">削除</button>
+            <button type="submit" id="deleteDeckButton" class="btn btn-danger">削除</button>
         </div>
     </form>
 </div>

--- a/templates/edit-deck.html
+++ b/templates/edit-deck.html
@@ -23,8 +23,10 @@
                     {% for card in cards %}
                     <tr>
                         <td>{{ card.id }}</td>
-                        <td><a href="{{ card.face }}">{{ card.face | split(pat="/") | last }}</td>
-                        <td><a href="{{ card.back }}">{{ card.back | split(pat="/") | last }}</td>
+                        <td><img src="{{ card.face }}" width="40" height="60" /><a href="{{ card.face }}">{{ card.face |
+                                split(pat="/") | last }}</td>
+                        <td><img src="{{ card.back }}" width="40" height="60" /><a href="{{ card.back }}">{{ card.back |
+                                split(pat="/") | last }}</td>
                         <td><button class="btn btn-primary card-move-button" id="move-{{ card.id }}"
                                 data-face="{{ card.face }}" data-back="{{ card.back }}">＞</button></td>
                     </tr>
@@ -71,8 +73,10 @@
                             <td><button type="button" class="btn btn-primary card-remove-button"
                                     id="remove-{{ card_in_deck.card_id }}">＜</button></td>
                             <td>{{ card_in_deck.card_id }}</td>
-                            <td><a href="{{ card_in_deck.face }}">{{ card_in_deck.face | split(pat="/") | last }}</td>
-                            <td><a href="{{ card_in_deck.back }}">{{ card_in_deck.back | split(pat="/") | last }}</td>
+                            <td><img src="{{ card_in_deck.face }}" width="40" height="60" /><a
+                                    href="{{ card_in_deck.face }}">{{ card_in_deck.face | split(pat="/") | last }}</td>
+                            <td><img src="{{ card_in_deck.back }}" width="40" height="60" /><a
+                                    href="{{ card_in_deck.back }}">{{ card_in_deck.back | split(pat="/") | last }}</td>
                             <td>
                                 <input type="number" class="card-num-input" name="{{ card_in_deck.card_id }}"
                                     id="num-{{ card_in_deck.card_id }}" value="{{ card_in_deck.num }}" required>

--- a/templates/edit-deck.html
+++ b/templates/edit-deck.html
@@ -23,8 +23,8 @@
                     {% for card in cards %}
                     <tr>
                         <td>{{ card.id }}</td>
-                        <td><a href="{{ card.face }}">{{ card.face }}</td>
-                        <td><a href="{{ card.back }}">{{ card.back }}</td>
+                        <td><a href="{{ card.face }}">{{ card.face | split(pat="/") | last }}</td>
+                        <td><a href="{{ card.back }}">{{ card.back | split(pat="/") | last }}</td>
                         <td><button class="btn btn-primary card-move-button" id="move-{{ card.id }}"
                                 data-face="{{ card.face }}" data-back="{{ card.back }}">＞</button></td>
                     </tr>
@@ -37,7 +37,7 @@
             <h2>デッキを作成してください</h2>
             <a href="/deck">デッキ作成</a>
             {% else %}
-            <h2>{{ selected_deck_name }}のカード一覧</h2>
+            <h2>{{ selected_deck_name }}</h2>
             <div class="form-group w-25 m-0">
                 <select id="deckSelect" class="form-control" name="deck_id">
                     {% for deck in decks %}
@@ -71,8 +71,8 @@
                             <td><button type="button" class="btn btn-primary card-remove-button"
                                     id="remove-{{ card_in_deck.card_id }}">＜</button></td>
                             <td>{{ card_in_deck.card_id }}</td>
-                            <td><a href="{{ card_in_deck.face }}">{{ card_in_deck.face }}</td>
-                            <td><a href="{{ card_in_deck.back }}">{{ card_in_deck.back }}</td>
+                            <td><a href="{{ card_in_deck.face }}">{{ card_in_deck.face | split(pat="/") | last }}</td>
+                            <td><a href="{{ card_in_deck.back }}">{{ card_in_deck.back | split(pat="/") | last }}</td>
                             <td>
                                 <input type="number" class="card-num-input" name="{{ card_in_deck.card_id }}"
                                     id="num-{{ card_in_deck.card_id }}" value="{{ card_in_deck.num }}" required>

--- a/templates/edit-deck.html
+++ b/templates/edit-deck.html
@@ -144,10 +144,16 @@
                             <td><button type="button" class="btn btn-primary card-remove-button"
                                     id="remove-${cardId}">＜</button></td>
                             <td>${cardId}</td>
-                            <td><a href="${cardFace}">${cardFace}</td>
-                            <td><a href="${cardBack}">${cardBack}</td>
+                            <td><img src="${cardFace}" width="40" height="60"
+                                    onmouseover="this.width=320; this.height=480"
+                                    onmouseout="this.width=40; this.height=60" />
+                                <a href="${cardFace}">${cardFace.split("/").pop().split(".").shift().slice(0, 10)}</td>
+                            <td><img src="${cardBack}" width="40" height="60"
+                                    onmouseover="this.width=320; this.height=480"
+                                    onmouseout="this.width=40; this.height=60" />
+                                <a href="${cardBack}">${cardBack.split("/").pop().split(".").shift().slice(0, 10)}</td>
                             <td>
-                                <input type="number" class="card-num-input text-danger" 
+                                <input type="number" class="card-num-input text-danger" style="width:50px;"
                                     name="${cardId}" id="num-${cardId}" value="1" required>
                             </td>
                         </tr>

--- a/templates/edit-deck.html
+++ b/templates/edit-deck.html
@@ -23,9 +23,14 @@
                     {% for card in cards %}
                     <tr>
                         <td>{{ card.id }}</td>
-                        <td><img src="{{ card.face }}" width="40" height="60" /><a href="{{ card.face }}">{{ card.face |
+                        <td><img src="{{ card.face }}" width="40" height="60"
+                                onmouseover="this.width=320; this.height=480"
+                                onmouseout="this.width=40; this.height=60" /><a href="{{ card.face }}">{{
+                                card.face |
                                 split(pat="/") | last }}</td>
-                        <td><img src="{{ card.back }}" width="40" height="60" /><a href="{{ card.back }}">{{ card.back |
+                        <td><img src="{{ card.back }}" width="40" height="60"
+                                onmouseover="this.width=320; this.height=480"
+                                onmouseout="this.width=40; this.height=60" /><a href="{{ card.back }}">{{ card.back |
                                 split(pat="/") | last }}</td>
                         <td><button class="btn btn-primary card-move-button" id="move-{{ card.id }}"
                                 data-face="{{ card.face }}" data-back="{{ card.back }}">＞</button></td>
@@ -73,10 +78,14 @@
                             <td><button type="button" class="btn btn-primary card-remove-button"
                                     id="remove-{{ card_in_deck.card_id }}">＜</button></td>
                             <td>{{ card_in_deck.card_id }}</td>
-                            <td><img src="{{ card_in_deck.face }}" width="40" height="60" /><a
-                                    href="{{ card_in_deck.face }}">{{ card_in_deck.face | split(pat="/") | last }}</td>
-                            <td><img src="{{ card_in_deck.back }}" width="40" height="60" /><a
-                                    href="{{ card_in_deck.back }}">{{ card_in_deck.back | split(pat="/") | last }}</td>
+                            <td><img src="{{ card_in_deck.face }}" width="40" height="60"
+                                    onmouseover="this.width=320; this.height=480"
+                                    onmouseout="this.width=40; this.height=60" /><a href="{{ card_in_deck.face }}">{{
+                                    card_in_deck.face | split(pat="/") | last }}</td>
+                            <td><img src="{{ card_in_deck.back }}" width="40" height="60"
+                                    onmouseover="this.width=320; this.height=480"
+                                    onmouseout="this.width=40; this.height=60" /><a href="{{ card_in_deck.back }}">{{
+                                    card_in_deck.back | split(pat="/") | last }}</td>
                             <td>
                                 <input type="number" class="card-num-input" name="{{ card_in_deck.card_id }}"
                                     id="num-{{ card_in_deck.card_id }}" value="{{ card_in_deck.num }}" required>

--- a/templates/edit-deck.html
+++ b/templates/edit-deck.html
@@ -23,15 +23,15 @@
                     {% for card in cards %}
                     <tr>
                         <td>{{ card.id }}</td>
-                        <td><img src="{{ card.face }}" width="40" height="60"
+                        <td><img class="lazyload" data-src="{{ card.face }}" width="40" height="60"
                                 onmouseover="this.width=320; this.height=480"
                                 onmouseout="this.width=40; this.height=60" /><a href="{{ card.face }}">{{
                                 card.face |
-                                split(pat="/") | last }}</td>
-                        <td><img src="{{ card.back }}" width="40" height="60"
+                                split(pat="/") | last | split(pat=".") | first | truncate(length=15) }}</td>
+                        <td><img class="lazyload" data-src="{{ card.back }}" width="40" height="60"
                                 onmouseover="this.width=320; this.height=480"
                                 onmouseout="this.width=40; this.height=60" /><a href="{{ card.back }}">{{ card.back |
-                                split(pat="/") | last }}</td>
+                                split(pat="/") | last | split(pat=".") | first | truncate(length=15) }}</td>
                         <td><button class="btn btn-primary card-move-button" id="move-{{ card.id }}"
                                 data-face="{{ card.face }}" data-back="{{ card.back }}">＞</button></td>
                     </tr>
@@ -78,14 +78,16 @@
                             <td><button type="button" class="btn btn-primary card-remove-button"
                                     id="remove-{{ card_in_deck.card_id }}">＜</button></td>
                             <td>{{ card_in_deck.card_id }}</td>
-                            <td><img src="{{ card_in_deck.face }}" width="40" height="60"
+                            <td><img class="lazyload" data-src="{{ card_in_deck.face }}" width="40" height="60"
                                     onmouseover="this.width=320; this.height=480"
                                     onmouseout="this.width=40; this.height=60" /><a href="{{ card_in_deck.face }}">{{
-                                    card_in_deck.face | split(pat="/") | last }}</td>
-                            <td><img src="{{ card_in_deck.back }}" width="40" height="60"
+                                    card_in_deck.face | split(pat="/") | last | split(pat=".") | first |
+                                    truncate(length=15) }}</td>
+                            <td><img class="lazyload" data-src="{{ card_in_deck.back }}" width="40" height="60"
                                     onmouseover="this.width=320; this.height=480"
                                     onmouseout="this.width=40; this.height=60" /><a href="{{ card_in_deck.back }}">{{
-                                    card_in_deck.back | split(pat="/") | last }}</td>
+                                    card_in_deck.back | split(pat="/") | last | split(pat=".") | first |
+                                    truncate(length=15) }}</td>
                             <td>
                                 <input type="number" class="card-num-input" name="{{ card_in_deck.card_id }}"
                                     id="num-{{ card_in_deck.card_id }}" value="{{ card_in_deck.num }}" required>
@@ -101,6 +103,9 @@
 </div>
 <script>
     window.onload = function () {
+        // 画像の遅延読み込み
+        lazyload();
+
         // 編集するデッキの変更
         const deckSelect = document.getElementById("deckSelect");
         deckSelect.addEventListener("change", function (event) {

--- a/templates/edit-deck.html
+++ b/templates/edit-deck.html
@@ -27,11 +27,11 @@
                                 onmouseover="this.width=320; this.height=480"
                                 onmouseout="this.width=40; this.height=60" /><a href="{{ card.face }}">{{
                                 card.face |
-                                split(pat="/") | last | split(pat=".") | first | truncate(length=15) }}</td>
+                                split(pat="/") | last | split(pat=".") | first | truncate(length=10) }}</td>
                         <td><img class="lazyload" data-src="{{ card.back }}" width="40" height="60"
                                 onmouseover="this.width=320; this.height=480"
                                 onmouseout="this.width=40; this.height=60" /><a href="{{ card.back }}">{{ card.back |
-                                split(pat="/") | last | split(pat=".") | first | truncate(length=15) }}</td>
+                                split(pat="/") | last | split(pat=".") | first | truncate(length=10) }}</td>
                         <td><button class="btn btn-primary card-move-button" id="move-{{ card.id }}"
                                 data-face="{{ card.face }}" data-back="{{ card.back }}">＞</button></td>
                     </tr>
@@ -82,12 +82,12 @@
                                     onmouseover="this.width=320; this.height=480"
                                     onmouseout="this.width=40; this.height=60" /><a href="{{ card_in_deck.face }}">{{
                                     card_in_deck.face | split(pat="/") | last | split(pat=".") | first |
-                                    truncate(length=15) }}</td>
+                                    truncate(length=10) }}</td>
                             <td><img class="lazyload" data-src="{{ card_in_deck.back }}" width="40" height="60"
                                     onmouseover="this.width=320; this.height=480"
                                     onmouseout="this.width=40; this.height=60" /><a href="{{ card_in_deck.back }}">{{
                                     card_in_deck.back | split(pat="/") | last | split(pat=".") | first |
-                                    truncate(length=15) }}</td>
+                                    truncate(length=10) }}</td>
                             <td>
                                 <input type="number" class="card-num-input" name="{{ card_in_deck.card_id }}"
                                     id="num-{{ card_in_deck.card_id }}" value="{{ card_in_deck.num }}" required>

--- a/templates/edit-deck.html
+++ b/templates/edit-deck.html
@@ -9,35 +9,37 @@
                 サーバー内のデッキを編集
             </p>
             <h2>カード一覧</h2>
-            <table class="table">
-                <thead>
-                    <tr>
-                        <th scope="col">ID</th>
-                        <th scope="col">表画像</th>
-                        <th scope="col">裏画像</th>
-                        <th scope="col">デッキへ</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <!--TODO リンクにホバーすると画像を表示するようにする -->
-                    {% for card in cards %}
-                    <tr>
-                        <td>{{ card.id }}</td>
-                        <td><img class="lazyload" data-src="{{ card.face }}" width="40" height="60"
-                                onmouseover="this.width=320; this.height=480"
-                                onmouseout="this.width=40; this.height=60" /><a href="{{ card.face }}">{{
-                                card.face |
-                                split(pat="/") | last | split(pat=".") | first | truncate(length=10) }}</td>
-                        <td><img class="lazyload" data-src="{{ card.back }}" width="40" height="60"
-                                onmouseover="this.width=320; this.height=480"
-                                onmouseout="this.width=40; this.height=60" /><a href="{{ card.back }}">{{ card.back |
-                                split(pat="/") | last | split(pat=".") | first | truncate(length=10) }}</td>
-                        <td><button class="btn btn-primary card-move-button" id="move-{{ card.id }}"
-                                data-face="{{ card.face }}" data-back="{{ card.back }}">＞</button></td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+            <div style="height:700px; overflow-y:scroll;">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th scope="col">ID</th>
+                            <th scope="col">表画像</th>
+                            <th scope="col">裏画像</th>
+                            <th scope="col">デッキへ</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for card in cards %}
+                        <tr>
+                            <td>{{ card.id }}</td>
+                            <td><img class="lazyload" data-src="{{ card.face }}" width="40" height="60"
+                                    onmouseover="this.width=320; this.height=480"
+                                    onmouseout="this.width=40; this.height=60" /><a href="{{ card.face }}">{{
+                                    card.face |
+                                    split(pat="/") | last | split(pat=".") | first | truncate(length=10) }}</td>
+                            <td><img class="lazyload" data-src="{{ card.back }}" width="40" height="60"
+                                    onmouseover="this.width=320; this.height=480"
+                                    onmouseout="this.width=40; this.height=60" /><a href="{{ card.back }}">{{ card.back
+                                    |
+                                    split(pat="/") | last | split(pat=".") | first | truncate(length=10) }}</td>
+                            <td><button class="btn btn-primary card-move-button" id="move-{{ card.id }}"
+                                    data-face="{{ card.face }}" data-back="{{ card.back }}">＞</button></td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
         </div>
         <div class="col-sm-6">
             {% if not is_deck_selected %}
@@ -62,40 +64,45 @@
                 <p>
                     {{ edit_deck_confirm }}
                 </p>
-                <table class="table" id="cardsInDeck" style="margin-top: 1.25rem!important;">
-                    <thead>
-                        <tr>
-                            <th scope="col">削除</th>
-                            <th scope="col">ID</th>
-                            <th scope="col">表画像</th>
-                            <th scope="col">裏画像</th>
-                            <th scope="col">枚数</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for card_in_deck in cards_in_deck %}
-                        <tr class="card-in-deck" id="tr-{{ card_in_deck.card_id }}">
-                            <td><button type="button" class="btn btn-primary card-remove-button"
-                                    id="remove-{{ card_in_deck.card_id }}">＜</button></td>
-                            <td>{{ card_in_deck.card_id }}</td>
-                            <td><img class="lazyload" data-src="{{ card_in_deck.face }}" width="40" height="60"
-                                    onmouseover="this.width=320; this.height=480"
-                                    onmouseout="this.width=40; this.height=60" /><a href="{{ card_in_deck.face }}">{{
-                                    card_in_deck.face | split(pat="/") | last | split(pat=".") | first |
-                                    truncate(length=10) }}</td>
-                            <td><img class="lazyload" data-src="{{ card_in_deck.back }}" width="40" height="60"
-                                    onmouseover="this.width=320; this.height=480"
-                                    onmouseout="this.width=40; this.height=60" /><a href="{{ card_in_deck.back }}">{{
-                                    card_in_deck.back | split(pat="/") | last | split(pat=".") | first |
-                                    truncate(length=10) }}</td>
-                            <td>
-                                <input type="number" class="card-num-input" name="{{ card_in_deck.card_id }}"
-                                    id="num-{{ card_in_deck.card_id }}" value="{{ card_in_deck.num }}" required>
-                            </td>
-                        </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
+                <div style="height:700px; overflow-y:scroll;">
+                    <table class="table" id="cardsInDeck" style="margin-top: 1.25rem!important;">
+                        <thead>
+                            <tr>
+                                <th scope="col">削除</th>
+                                <th scope="col">ID</th>
+                                <th scope="col">表画像</th>
+                                <th scope="col">裏画像</th>
+                                <th scope="col">枚数</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for card_in_deck in cards_in_deck %}
+                            <tr class="card-in-deck" id="tr-{{ card_in_deck.card_id }}">
+                                <td><button type="button" class="btn btn-primary card-remove-button"
+                                        id="remove-{{ card_in_deck.card_id }}">＜</button></td>
+                                <td>{{ card_in_deck.card_id }}</td>
+                                <td><img class="lazyload" data-src="{{ card_in_deck.face }}" width="40" height="60"
+                                        onmouseover="this.width=320; this.height=480"
+                                        onmouseout="this.width=40; this.height=60" /><a
+                                        href="{{ card_in_deck.face }}">{{
+                                        card_in_deck.face | split(pat="/") | last | split(pat=".") | first |
+                                        truncate(length=10) }}</td>
+                                <td><img class="lazyload" data-src="{{ card_in_deck.back }}" width="40" height="60"
+                                        onmouseover="this.width=320; this.height=480"
+                                        onmouseout="this.width=40; this.height=60" /><a
+                                        href="{{ card_in_deck.back }}">{{
+                                        card_in_deck.back | split(pat="/") | last | split(pat=".") | first |
+                                        truncate(length=10) }}</td>
+                                <td>
+                                    <input type="number" class="card-num-input" style="width:50px;"
+                                        name="{{ card_in_deck.card_id }}" id="num-{{ card_in_deck.card_id }}"
+                                        value="{{ card_in_deck.num }}" required>
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
             </form>
             {% endif %}
         </div>


### PR DESCRIPTION
# 概要

- デッキ編集画面UIの変更
  - 小さいサムネイルを表示(重くならないように[lazyload](https://github.com/tuupola/lazyload)で遅延読み込み)
  - 左右それぞれ個別でスクロール
  - サムネイルにマウスカーソルを合わせると拡大 #10 
  - パス全体ではなくファイル名の先頭10文字だけ表示
- 開発用に[cargo-watch](https://crates.io/crates/cargo-watch)を追加
  - `cargo watch -x run` でコード変更するとビルドが自動で行われる(ブラウザの更新は必要)

# 動作確認

```
cargo install cargo-watch
cargo watch -x run
```

![test](https://user-images.githubusercontent.com/43720583/104115564-091a2a00-5354-11eb-8cd4-b3441c38e8c3.gif)


# 関連するクライアントの変更

なし
