### PR TITLE
ルームリストをjsonで返すように変更

### DIFF
--- a/src/ws_session.rs
+++ b/src/ws_session.rs
@@ -302,9 +302,18 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsChatSession {
                                 .then(|res, _, ctx| {
                                     match res {
                                         Ok(rooms) => {
-                                            for room in rooms {
-                                                ctx.text(room);
+                                            let mut data = String::from("{ \"data\": [");
+                                            for (index, room) in rooms.iter().enumerate() {
+                                                data.push_str("{ \"name\": \"");
+                                                data.push_str(&room);
+                                                if index == rooms.len() - 1 {
+                                                    data.push_str("\" } ");
+                                                } else {
+                                                    data.push_str("\" }, ");
+                                                }
                                             }
+                                            data.push_str("] }");
+                                            ctx.text(data);
                                         }
                                         _ => println!("Something is wrong"),
                                     }


### PR DESCRIPTION
# 概要

ルームリストをjsonで返すように変更．

# 動作確認

- サーバー起動後[gosandy](https://app.gosandy.io/)などで"ws://localhost:8080/ws"に`"/list"`をsendすると`{"data": [{"name": "Main"}]}`が返ってくる
- 下記のクライアント側のPRに書いた動作確認を行ってください

# 関連するクライアントの変更

クライアント側でルーム一覧の取得とルーム作成およびルーム入室をgraphQLからwebsocketでできるように変更しました．(https://github.com/2d-rpg/card-playroom-client/pull/21)
