### PR TITLE
ルームidで管理

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,6 +627,7 @@ dependencies = [
  "tera",
  "tokio",
  "tokio-util",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -1076,6 +1077,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4060f4657be78b8e766215b02b18a2e862d83745545de804638e2b545e81aee6"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "gimli"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,7 +1308,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "url",
- "uuid",
+ "uuid 0.7.4",
 ]
 
 [[package]]
@@ -1801,7 +1813,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
  "libc",
  "rand_chacha",
  "rand_core",
@@ -1824,7 +1836,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
 ]
 
 [[package]]
@@ -2527,6 +2539,16 @@ name = "uuid"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.1",
+ "serde",
+]
 
 [[package]]
 name = "v_escape"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ env_logger = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # json = "0.12"
+uuid = { version = "0.8", features = ["serde", "v4"] }
 dotenv = "0.15"
 juniper = "0.14"
 juniper-from-schema = "0.5"

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -8,6 +8,7 @@ use byteorder::{BigEndian, ByteOrder};
 use bytes::{BufMut, BytesMut};
 use serde::{Deserialize, Serialize};
 use serde_json as json;
+use uuid::Uuid;
 
 /// Client request
 #[derive(Serialize, Deserialize, Debug, Message)]
@@ -17,7 +18,7 @@ pub enum ChatRequest {
     /// List rooms
     List,
     /// Join rooms
-    Join(u32),
+    Join(Uuid),
     /// Send message
     Message(String),
     /// Ping
@@ -32,10 +33,10 @@ pub enum ChatResponse {
     Ping,
 
     /// List of rooms
-    Rooms(Vec<ws_session::Room>),
+    Rooms(Vec<ws_session::RoomInfo>),
 
     /// Joined
-    Joined(u32),
+    Joined(Uuid),
 
     /// Message
     Message(String),

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -17,7 +17,7 @@ pub enum ChatRequest {
     /// List rooms
     List,
     /// Join rooms
-    Join(usize),
+    Join(u32),
     /// Send message
     Message(String),
     /// Ping
@@ -35,7 +35,7 @@ pub enum ChatResponse {
     Rooms(Vec<ws_session::Room>),
 
     /// Joined
-    Joined(usize),
+    Joined(u32),
 
     /// Message
     Message(String),

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 use std::io;
 
+use crate::ws_session;
 use actix::prelude::*;
 use actix_codec::{Decoder, Encoder};
 use byteorder::{BigEndian, ByteOrder};
@@ -16,7 +17,7 @@ pub enum ChatRequest {
     /// List rooms
     List,
     /// Join rooms
-    Join(String),
+    Join(usize),
     /// Send message
     Message(String),
     /// Ping
@@ -31,10 +32,10 @@ pub enum ChatResponse {
     Ping,
 
     /// List of rooms
-    Rooms(Vec<String>),
+    Rooms(Vec<ws_session::Room>),
 
     /// Joined
-    Joined(String),
+    Joined(usize),
 
     /// Message
     Message(String),

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -33,7 +33,7 @@ pub enum ChatResponse {
     Ping,
 
     /// List of rooms
-    Rooms(Vec<ws_session::RoomInfo>),
+    Rooms(ws_session::RoomInfoList),
 
     /// Joined
     Joined(Uuid),

--- a/src/ws_actors.rs
+++ b/src/ws_actors.rs
@@ -164,9 +164,9 @@ impl ChatServer {
             };
             rooms.push(room);
         }
-        let mut data = String::from("{ \"data\": [");
+        let mut data = String::from("{ \"data\": ");
         data.push_str(&serde_json::to_string(&ws_session::RoomInfoList { rooms }).unwrap());
-        data.push_str("] }");
+        data.push_str(" }");
 
         self.send_all(&data);
     }

--- a/src/ws_actors.rs
+++ b/src/ws_actors.rs
@@ -90,19 +90,6 @@ impl Room {
     }
 }
 
-pub struct MessageData {
-    event: String,
-    status: String,
-    data: DataType,
-    message: String,
-}
-
-pub enum DataType {
-    RoomList(ws_session::RoomInfoList),
-    Room(ws_session::RoomInfo),
-    Position(String),
-}
-
 /// `ChatServer` manages chat rooms and responsible for coordinating chat
 /// session. implementation is super primitive
 pub struct ChatServer {
@@ -112,16 +99,6 @@ pub struct ChatServer {
 
 impl Default for ChatServer {
     fn default() -> ChatServer {
-        // TODO default room 必要？
-        // let mut rooms = HashMap::new();
-        // rooms.insert(
-        //     Uuid::new_v4(),
-        //     Room {
-        //         name: "メインルーム(デフォルト)".to_owned(),
-        //         memebrs: HashSet::new(),
-        //     },
-        // );
-
         ChatServer {
             sessions: HashMap::new(),
             rooms: HashMap::new(),
@@ -173,7 +150,8 @@ impl ChatServer {
 
     fn add_room(&mut self, session_id: &Uuid, room_name: &str) -> MessageResult<Create> {
         self.rooms.insert(
-            session_id.clone(), // room id becomes room host session id
+            // room id becomes room host session id
+            session_id.clone(),
             Room {
                 name: room_name.to_owned(),
                 members: HashSet::new(),
@@ -289,25 +267,6 @@ impl Handler<Join> for ChatServer {
             session_id,
             room_id,
         } = msg;
-        // let mut rooms = Vec::new();
-
-        // remove session from all rooms
-        // for (room_id, sessions) in &mut self.roomusers {
-        //     if sessions.remove(&id) {
-        //         rooms.push(room_id);
-        //     }
-        // }
-        // send message to other users
-        // for room in rooms {
-        //     self.send_message(&room, "Someone disconnected", 0);
-        // }
-
-        // create room if the named room does not exist
-        // if self.roomnames.get_mut(&roomid).is_none() {
-        //     let roomid = self.rng.gen::<usize>();
-        //     self.roomnames.insert(name.clone(), roomid);
-        //     self.roomusers.insert(roomid, HashSet::new());
-        // }
 
         // send all users in the room except self
         self.send_message(&room_id, "Someone connected", session_id);

--- a/src/ws_actors.rs
+++ b/src/ws_actors.rs
@@ -198,6 +198,7 @@ impl Handler<ListRooms> for ChatServer {
             let room = ws_session::Room {
                 id: *id,
                 name: name.clone(),
+                num: self.roomusers.get(id).unwrap().len(),
             };
             rooms.push(room);
         }

--- a/src/ws_actors.rs
+++ b/src/ws_actors.rs
@@ -32,15 +32,15 @@ pub struct Message {
     pub id: usize,
     /// Peer message
     pub msg: String,
-    /// Room name
-    pub room: String,
+    /// Room id
+    pub room: usize,
 }
 
 /// List of available rooms
 pub struct ListRooms;
 
 impl actix::Message for ListRooms {
-    type Result = Vec<String>;
+    type Result = Vec<ws_session::Room>;
 }
 
 /// Join room, if room does not exists create new one.
@@ -49,36 +49,59 @@ impl actix::Message for ListRooms {
 pub struct Join {
     /// Client id
     pub id: usize,
+    /// Room id
+    pub roomid: usize,
+}
+
+pub struct Create {
+    /// Client id
+    pub id: usize,
     /// Room name
-    pub name: String,
+    pub roomname: String,
+}
+
+pub struct CreateRoom {
+    pub id: usize,
+    pub roomname: String,
+    pub exists: bool,
+}
+
+impl actix::Message for Create {
+    type Result = CreateRoom;
 }
 
 /// `ChatServer` manages chat rooms and responsible for coordinating chat
 /// session. implementation is super primitive
 pub struct ChatServer {
     sessions: HashMap<usize, Recipient<ws_session::Message>>,
-    rooms: HashMap<String, HashSet<usize>>,
+    roomusers: HashMap<usize, HashSet<usize>>,
+    roomnames: HashMap<String, usize>,
     rng: ThreadRng,
 }
 
 impl Default for ChatServer {
     fn default() -> ChatServer {
         // default room
-        let mut rooms = HashMap::new();
-        rooms.insert("Main".to_owned(), HashSet::new());
+        let mut roomusers = HashMap::new();
+        let mut roomnames = HashMap::new();
+        let mut rng = rand::thread_rng();
+        let main_room_id = rng.gen::<usize>();
+        roomusers.insert(main_room_id, HashSet::new());
+        roomnames.insert("Main".to_owned(), main_room_id);
 
         ChatServer {
             sessions: HashMap::new(),
-            rooms,
-            rng: rand::thread_rng(),
+            roomusers: roomusers,
+            roomnames: roomnames,
+            rng: rng,
         }
     }
 }
 
 impl ChatServer {
     /// Send message to all users in the room
-    fn send_message(&self, room: &str, message: &str, skip_id: usize) {
-        if let Some(sessions) = self.rooms.get(room) {
+    fn send_message(&self, room: &usize, message: &str, skip_id: usize) {
+        if let Some(sessions) = self.roomusers.get(room) {
             for id in sessions {
                 println!("{}", id);
                 if *id != skip_id {
@@ -109,14 +132,21 @@ impl Handler<Connect> for ChatServer {
         println!("Someone joined");
 
         // notify all users in same room
-        self.send_message(&"Main".to_owned(), "Someone joined", 0);
+        self.send_message(
+            self.roomnames.get(&"Main".to_owned()).unwrap(),
+            "Someone joined",
+            0,
+        );
 
         // register session with random id
         let id = self.rng.gen::<usize>();
         self.sessions.insert(id, msg.addr);
 
         // auto join session to Main room
-        self.rooms.get_mut(&"Main".to_owned()).unwrap().insert(id);
+        self.roomusers
+            .get_mut(self.roomnames.get(&"Main".to_owned()).unwrap())
+            .unwrap()
+            .insert(id);
 
         // send id back
         id
@@ -130,21 +160,21 @@ impl Handler<Disconnect> for ChatServer {
     fn handle(&mut self, msg: Disconnect, _: &mut Context<Self>) {
         println!("Someone disconnected");
 
-        let mut rooms: Vec<String> = Vec::new();
+        let mut rooms: Vec<&usize> = Vec::new();
 
         // remove address
         if self.sessions.remove(&msg.id).is_some() {
             // remove session from all rooms
-            for (name, sessions) in &mut self.rooms {
+            for (roomid, sessions) in &mut self.roomusers {
                 if sessions.remove(&msg.id) {
-                    rooms.push(name.to_owned());
+                    rooms.push(roomid);
                 }
             }
         }
         // send message to other users
-        for room in rooms {
-            self.send_message(&room, "Someone disconnected", 0);
-        }
+        // for room in rooms {
+        //     self.send_message(&room, "Someone disconnected", 0);
+        // }
     }
 }
 
@@ -164,8 +194,12 @@ impl Handler<ListRooms> for ChatServer {
     fn handle(&mut self, _: ListRooms, _: &mut Context<Self>) -> Self::Result {
         let mut rooms = Vec::new();
 
-        for key in self.rooms.keys() {
-            rooms.push(key.to_owned())
+        for (name, id) in &self.roomnames {
+            let room = ws_session::Room {
+                id: *id,
+                name: name.clone(),
+            };
+            rooms.push(room);
         }
 
         MessageResult(rooms)
@@ -178,24 +212,60 @@ impl Handler<Join> for ChatServer {
     type Result = ();
 
     fn handle(&mut self, msg: Join, _: &mut Context<Self>) {
-        let Join { id, name } = msg;
-        let mut rooms = Vec::new();
+        let Join { id, roomid } = msg;
+        // let mut rooms = Vec::new();
 
         // remove session from all rooms
-        for (n, sessions) in &mut self.rooms {
-            if sessions.remove(&id) {
-                rooms.push(n.to_owned());
-            }
-        }
+        // for (room_id, sessions) in &mut self.roomusers {
+        //     if sessions.remove(&id) {
+        //         rooms.push(room_id);
+        //     }
+        // }
         // send message to other users
-        for room in rooms {
-            self.send_message(&room, "Someone disconnected", 0);
-        }
+        // for room in rooms {
+        //     self.send_message(&room, "Someone disconnected", 0);
+        // }
 
-        if self.rooms.get_mut(&name).is_none() {
-            self.rooms.insert(name.clone(), HashSet::new());
+        // create room if the named room does not exist
+        // if self.roomnames.get_mut(&roomid).is_none() {
+        //     let roomid = self.rng.gen::<usize>();
+        //     self.roomnames.insert(name.clone(), roomid);
+        //     self.roomusers.insert(roomid, HashSet::new());
+        // }
+
+        // send all users in the room except self
+        self.send_message(&roomid, "Someone connected", id);
+        println!("{:?}", self.roomnames);
+        println!("{:?}", self.roomusers);
+        // add session id
+        self.roomusers.get_mut(&roomid).unwrap().insert(id);
+    }
+}
+
+impl Handler<Create> for ChatServer {
+    type Result = MessageResult<Create>;
+
+    fn handle(&mut self, msg: Create, _: &mut Context<Self>) -> Self::Result {
+        let Create { id, roomname } = msg;
+
+        if self.roomnames.get_mut(&roomname).is_none() {
+            // create room if the named room does not exist
+            let roomid = self.rng.gen::<usize>();
+            self.roomnames.insert(roomname.clone(), roomid);
+            self.roomusers.insert(roomid, HashSet::new());
+            // self.roomusers.get_mut(&roomid).unwrap().insert(id);
+            return MessageResult(CreateRoom {
+                id: roomid,
+                roomname: roomname,
+                exists: false,
+            });
+        } else {
+            // return error if already exists
+            return MessageResult(CreateRoom {
+                id: *self.roomnames.get(&roomname).unwrap(),
+                roomname: roomname,
+                exists: true,
+            });
         }
-        self.send_message(&name, "Someone connected", id);
-        self.rooms.get_mut(&name).unwrap().insert(id);
     }
 }

--- a/src/ws_session.rs
+++ b/src/ws_session.rs
@@ -36,6 +36,11 @@ pub struct RoomInfo {
     pub num: usize,
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RoomInfoList {
+    pub rooms: Vec<RoomInfo>,
+}
+
 /// `ChatSession` actor is responsible for tcp peer communications.
 pub struct ChatSession {
     /// unique session id
@@ -316,19 +321,7 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsChatSession {
                                     match res {
                                         Ok(rooms) => {
                                             let mut data = String::from("{ \"data\": [");
-                                            for (index, room) in rooms.iter().enumerate() {
-                                                // data.push_str("{ \"name\": \"");
-                                                data.push_str(
-                                                    &serde_json::to_string(room).unwrap(),
-                                                );
-                                                if index == rooms.len() - 1 {
-                                                    // data.push_str("\" } ");
-                                                    data.push_str(" ");
-                                                } else {
-                                                    // data.push_str("\" }, ");
-                                                    data.push_str(", ");
-                                                }
-                                            }
+                                            data.push_str(&serde_json::to_string(&rooms).unwrap());
                                             data.push_str("] }");
                                             ctx.text(data);
                                         }

--- a/src/ws_session.rs
+++ b/src/ws_session.rs
@@ -166,7 +166,8 @@ impl ChatSession {
             id: Uuid::new_v4(),
             addr,
             hb: Instant::now(),
-            room: None, // defaultルームへの割り当てなし
+            // defaultルームへの割り当てなし
+            room: None,
             framed,
         }
     }

--- a/src/ws_session.rs
+++ b/src/ws_session.rs
@@ -32,6 +32,7 @@ pub struct Message(pub String);
 pub struct Room {
     pub id: u32,
     pub name: String,
+    pub num: usize,
 }
 
 /// `ChatSession` actor is responsible for tcp peer communications.
@@ -374,6 +375,7 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsChatSession {
                                                         &serde_json::to_string(&Room {
                                                             id: createroom.id,
                                                             name: createroom.roomname,
+                                                            num: 0
                                                         })
                                                         .unwrap(),
                                                     );

--- a/src/ws_session.rs
+++ b/src/ws_session.rs
@@ -320,9 +320,9 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsChatSession {
                                 .then(|res, _, ctx| {
                                     match res {
                                         Ok(rooms) => {
-                                            let mut data = String::from("{ \"data\": [");
+                                            let mut data = String::from("{ \"data\": ");
                                             data.push_str(&serde_json::to_string(&rooms).unwrap());
-                                            data.push_str("] }");
+                                            data.push_str(" }");
                                             ctx.text(data);
                                         }
                                         _ => println!("Something is wrong"),


### PR DESCRIPTION
# 概要

ルーム名で管理していたものをルームidで管理するよう変更．

# 動作確認

サーバ起動後、[gosandy](https://app.gosandy.io/)などで、`ws://localhost:8080/ws`に接続し、`"/list"`, `"/create roomname"`, `/join ${roomid}`, `"Hello"`などを行う。

# 関連するクライアントの変更

クライアント側でルームidでルームに関する操作を行うよう変更しました．(https://github.com/2d-rpg/card-playroom-client/pull/21)

# issue

- #17 
