### PR TITLE
部屋内での複数のカードの位置の同期のためのWebSocketメッセージの実装

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -15,7 +15,7 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Build
-        run: cargo build --verbose
+      - name: Check
+        run: cargo check --verbose
       - name: Run tests
         run: cargo test --verbose

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -161,8 +161,6 @@ pub struct CardInfo {
     pub index: i32,
     pub own: bool,
     pub position: CardPosition,
-    pub initx: f32,
-    pub inity: f32,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CardInfoList {

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -151,11 +151,9 @@ pub struct ChatMessage(pub String);
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CardInfo {
     pub index: i32,
-    pub is_own: bool,
-    pub position_x: i32,
-    pub position_y: i32,
-    pub init_x: i32,
-    pub init_y: i32,
+    pub own: bool,
+    pub x: f32,
+    pub y: f32,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CardInfoList {

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -149,11 +149,20 @@ const CLIENT_TIMEOUT: Duration = Duration::from_secs(10);
 pub struct ChatMessage(pub String);
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CardPosition {
+    x: f32,
+    y: f32,
+}
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CardInfo {
+    pub id: i32,
+    pub face: String,
+    pub back: String,
     pub index: i32,
     pub own: bool,
-    pub x: f32,
-    pub y: f32,
+    pub position: CardPosition,
+    pub initx: f32,
+    pub inity: f32,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CardInfoList {

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -163,8 +163,6 @@ pub struct CardInfo {
     pub index: i32,
     pub own: bool,
     pub position: CardPosition,
-    pub offsetx: f32,
-    pub offsety: f32,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CardInfoList {

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -163,6 +163,8 @@ pub struct CardInfo {
     pub index: i32,
     pub own: bool,
     pub position: CardPosition,
+    pub offsetx: f32,
+    pub offsety: f32,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CardInfoList {

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -41,8 +41,8 @@ pub enum Event {
     GetRoomList,
     /// event for someone entering room
     SomeoneEnterRoom,
-    /// event for receive cards info
-    CardsInfo,
+    /// event for receive first cards info
+    FirstCardsInfo,
     /// unexpected event
     Unknown,
 }

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -41,6 +41,8 @@ pub enum Event {
     GetRoomList,
     /// event for someone entering room
     SomeoneEnterRoom,
+    /// event for receive cards info
+    CardsInfo,
     /// unexpected event
     Unknown,
 }
@@ -147,6 +149,20 @@ const CLIENT_TIMEOUT: Duration = Duration::from_secs(10);
 pub struct ChatMessage(pub String);
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CardInfo {
+    pub index: i32,
+    pub is_own: bool,
+    pub position_x: i32,
+    pub position_y: i32,
+    pub init_x: i32,
+    pub init_y: i32,
+}
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CardInfoList {
+    pub cards: Vec<CardInfo>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RoomInfo {
     pub id: Uuid,
     pub name: String,
@@ -184,6 +200,17 @@ impl RoomInfoList {
     pub fn get_json_data(&self, status: Status, event: Event) -> String {
         serde_json::to_string(&WsMessage {
             data: self.clone().rooms,
+            event,
+            status,
+        })
+        .unwrap()
+    }
+}
+
+impl CardInfoList {
+    pub fn get_json_data(&self, status: Status, event: Event) -> String {
+        serde_json::to_string(&WsMessage {
+            data: self.clone().cards,
             event,
             status,
         })

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -43,6 +43,8 @@ pub enum Event {
     SomeoneEnterRoom,
     /// event for receive first cards info
     FirstCardsInfo,
+    /// event for receive cards info (not first)
+    CardsInfo,
     /// unexpected event
     Unknown,
 }

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -39,6 +39,8 @@ pub enum Event {
     EnterRoom,
     /// event for getting room list
     GetRoomList,
+    /// event for someone entering room
+    SomeoneEnterRoom,
     /// unexpected event
     Unknown,
 }
@@ -156,7 +158,7 @@ pub struct RoomInfoList {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ErrorMessage {
+pub struct SimpleMessage {
     pub message: String,
 }
 
@@ -189,7 +191,7 @@ impl RoomInfoList {
     }
 }
 
-impl ErrorMessage {
+impl SimpleMessage {
     pub fn get_json_data(&self, status: Status, event: Event) -> String {
         serde_json::to_string(&WsMessage {
             data: self.clone(),

--- a/src/websocket/room_manager.rs
+++ b/src/websocket/room_manager.rs
@@ -175,7 +175,11 @@ impl Handler<Join> for ChatServer {
         } = msg;
 
         // send all users in the room except self
-        self.send_message(&room_id, "Someone connected", session_id);
+        let msg = SimpleMessage {
+            message: "Someone is connected".to_string(),
+        }
+        .get_json_data(Status::Ok, Event::SomeoneEnterRoom);
+        self.send_message(&room_id, &msg, session_id);
         // add session id
         self.rooms
             .get_mut(&room_id)

--- a/src/websocket/websocket_session.rs
+++ b/src/websocket/websocket_session.rs
@@ -202,7 +202,7 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsChatSession {
                                     self.addr.do_send(Message {
                                         id: self.id,
                                         msg: card_info_list
-                                            .get_json_data(Status::Ok, Event::CardsInfo),
+                                            .get_json_data(Status::Ok, Event::FirstCardsInfo),
                                         room: room,
                                     })
                                 }

--- a/src/websocket/websocket_session.rs
+++ b/src/websocket/websocket_session.rs
@@ -195,10 +195,13 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsChatSession {
                         "/cards" => {
                             if v.len() == 2 {
                                 let msg = v[1].to_owned();
+                                let card_info: Vec<CardInfo> = serde_json::from_str(&msg).unwrap();
+                                let card_info_list = CardInfoList { cards: card_info };
                                 if let Some(room) = self.room {
                                     self.addr.do_send(Message {
                                         id: self.id,
-                                        msg,
+                                        msg: card_info_list
+                                            .get_json_data(Status::Ok, Event::CardsInfo),
                                         room: room,
                                     })
                                 }

--- a/src/websocket/websocket_session.rs
+++ b/src/websocket/websocket_session.rs
@@ -147,7 +147,7 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsChatSession {
                                     .wait(ctx)
                             } else {
                                 ctx.text(
-                                    ErrorMessage {
+                                    SimpleMessage {
                                         message: "!!! room id is required".to_string(),
                                     }
                                     .get_json_data(Status::Error, Event::EnterRoom),
@@ -185,7 +185,7 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsChatSession {
                                     .wait(ctx)
                             } else {
                                 ctx.text(
-                                    ErrorMessage {
+                                    SimpleMessage {
                                         message: "!!! room name is required".to_string(),
                                     }
                                     .get_json_data(Status::Error, Event::Unknown),
@@ -204,15 +204,15 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsChatSession {
                                 }
                             } else {
                                 ctx.text(
-                                    ErrorMessage {
-                                        message: "!!! name is required".to_string(),
+                                    SimpleMessage {
+                                        message: "!!! cards info is required".to_string(),
                                     }
                                     .get_json_data(Status::Error, Event::Unknown),
                                 );
                             }
                         }
                         _ => ctx.text(
-                            ErrorMessage {
+                            SimpleMessage {
                                 message: format!("!!! unknown command: {:?}", m),
                             }
                             .get_json_data(Status::Error, Event::Unknown),
@@ -220,7 +220,7 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsChatSession {
                     }
                 } else {
                     ctx.text(
-                        ErrorMessage {
+                        SimpleMessage {
                             message: "!!! message must starts with /".to_string(),
                         }
                         .get_json_data(Status::Error, Event::Unknown),

--- a/src/websocket/websocket_session.rs
+++ b/src/websocket/websocket_session.rs
@@ -195,6 +195,7 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsChatSession {
                         "/cards" => {
                             if v.len() == 2 {
                                 let msg = v[1].to_owned();
+                                dbg!(&msg);
                                 let card_info: Vec<CardInfo> = serde_json::from_str(&msg).unwrap();
                                 let card_info_list = CardInfoList { cards: card_info };
                                 if let Some(room) = self.room {

--- a/src/websocket/websocket_session.rs
+++ b/src/websocket/websocket_session.rs
@@ -192,7 +192,7 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsChatSession {
                                 );
                             }
                         }
-                        "/cards" => {
+                        "/first-cards" => {
                             if v.len() == 2 {
                                 let msg = v[1].to_owned();
                                 dbg!(&msg);
@@ -203,7 +203,30 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsChatSession {
                                         id: self.id,
                                         msg: card_info_list
                                             .get_json_data(Status::Ok, Event::FirstCardsInfo),
-                                        room: room,
+                                        room,
+                                    })
+                                }
+                            } else {
+                                ctx.text(
+                                    SimpleMessage {
+                                        message: "!!! cards info is required".to_string(),
+                                    }
+                                    .get_json_data(Status::Error, Event::Unknown),
+                                );
+                            }
+                        }
+                        "/cards" => {
+                            if v.len() == 2 {
+                                let msg = v[1].to_owned();
+                                dbg!(&msg);
+                                let card_info: Vec<CardInfo> = serde_json::from_str(&msg).unwrap();
+                                let card_info_list = CardInfoList { cards: card_info };
+                                if let Some(room) = self.room {
+                                    self.addr.do_send(Message {
+                                        id: self.id,
+                                        msg: card_info_list
+                                            .get_json_data(Status::Ok, Event::CardsInfo),
+                                        room,
                                     })
                                 }
                             } else {


### PR DESCRIPTION
# 概要

- 部屋内での複数のカードの位置の同期を実装するためWebsocketのメッセージの種類を増やした
  - SomeoneEnterRoom, FirstCardsInfo, CardsInfoのイベントとそれに合わせたメッセージの処理を実装
- github actionsのコマンドをbuildからcheckに変更(実行ファイルを生成せず早い)
  - [Hello, Cargo\! \- The Rust Programming Language 日本語版](https://doc.rust-jp.rs/book-ja/ch01-03-hello-cargo.html)
## クライアント，サーバー間でのカード情報送受信シーケンス図

![card-playroom-sequence](https://user-images.githubusercontent.com/43720583/115237052-0dc25b80-a157-11eb-9c5c-9795ad4dc24d.png)

# 動作確認

サーバーを起動した状態でクライアント側(feature/movable_deck)でデッキ作成後，同部屋に2端末で入室し，カードを移動させる

# 関連するクライアントの変更

[部屋内での複数のカードの位置の同期 by bana118 · Pull Request \#27 · 2d\-rpg/card\-playroom\-client](https://github.com/2d-rpg/card-playroom-client/pull/27)
